### PR TITLE
Optimizations to PAG and t2i-zero

### DIFF
--- a/scripts/pag.py
+++ b/scripts/pag.py
@@ -333,11 +333,11 @@ class PAGExtensionScript(UIWrapper):
                                 # oops we forgot to unhook
                                 return
 
-                        batch_size, seq_len, inner_dim = output.shape
-                        identity = torch.eye(seq_len).expand(batch_size, -1, -1).to(shared.device)
-
                         # get the last to_v output and save it
                         last_to_v = getattr(module, 'pag_last_to_v', None)
+
+                        batch_size, seq_len, inner_dim = output.shape
+                        identity = torch.eye(seq_len, dtype=last_to_v.dtype, device=shared.device).expand(batch_size, -1, -1)
                         if last_to_v is not None:    
                                 new_output = torch.einsum('bij,bjk->bik', identity, last_to_v)
                                 return new_output

--- a/scripts/t2i_zero.py
+++ b/scripts/t2i_zero.py
@@ -407,15 +407,15 @@ class T2I0ExtensionScript(UIWrapper):
                 plot_num = 0
                 for module in cross_attn_modules:
                         self.add_field_cross_attn_modules(module, 't2i0_last_attn_map', None)
-                        self.add_field_cross_attn_modules(module, 't2i0_step', torch.tensor([-1]).cpu())
-                        self.add_field_cross_attn_modules(module, 't2i0_step_start', torch.tensor([step_start]).cpu())
-                        self.add_field_cross_attn_modules(module, 't2i0_step_end', torch.tensor([step_end]).cpu())
+                        self.add_field_cross_attn_modules(module, 't2i0_step', int(-1))
+                        self.add_field_cross_attn_modules(module, 't2i0_step_start', int(step_start))
+                        self.add_field_cross_attn_modules(module, 't2i0_step_end', int(step_end))
                         self.add_field_cross_attn_modules(module, 't2i0_ema', None)
-                        self.add_field_cross_attn_modules(module, 't2i0_ema_factor', torch.tensor([ema_factor]).cpu())
-                        self.add_field_cross_attn_modules(module, 'plot_num', torch.tensor([plot_num]).to(device=shared.device))
+                        self.add_field_cross_attn_modules(module, 't2i0_ema_factor', float(ema_factor))
+                        self.add_field_cross_attn_modules(module, 'plot_num', int(plot_num))
                         self.add_field_cross_attn_modules(module, 't2i0_to_v_map', None)
                         self.add_field_cross_attn_modules(module.to_v, 't2i0_parent_module', [module])
-                        self.add_field_cross_attn_modules(module, 't2i0_token_count', torch.tensor(token_count).cpu())
+                        self.add_field_cross_attn_modules(module, 't2i0_token_count', int(token_count))
                         self.add_field_cross_attn_modules(module, 'gaussian_blur', GaussianBlur(kernel_size=3, sigma=1).to(device=shared.device))
                         if tokens is not None:
                                 self.add_field_cross_attn_modules(module, 't2i0_tokens', torch.tensor(tokens).to(device=shared.device, dtype=torch.int64))


### PR DESCRIPTION
I've made a few optimizations to PAG and t2i-zero.

For PAG, you might not notice the changes too much speed-wise, it's already unavoidably very slow.  One tensor was being created on CPU then moved to device.  This was a problem when using some proposed performance optimizations for A1111 particularly (https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15821).  Now these changes won't break PAG.

For t2i-zero, the changes are more substantial.  There were a lot of forced device syncs happening.  Summarizing the changes:
- 🗞️💥 A number of scalar values were being initialized as CUDA tensors then used as control flow.  That means `aten::item` is called on them, which forces a device sync.  None of them needed to be CUDA tensors to do anything else they were doing so I set them to all be CPU tensors, which removed the blocks.
- 🗞️💥 When token_indices was `None` or `[]`, this was creating a list of all tokens using `torch.tensor(list(range(1, token_count.item())))`, which causes a device sync for every single token in the sequence (!).  `torch.arange(1, token_count, device=output.device)` is much more suitable, and creates the tensor directly on-device.
- 🗞️💥 This one is Torchvision's fault.  GaussianBlur creates the kernels every time it is run on CPU and then moves them to the GPU, which -- you guessed it -- causes a forced device sync.  I submitted a patch to the torchvision repo.  You'll still have that forced device sync there in the mean time.  I changed it so that the module is not initialized multiple times every inference step as part of troubleshooting this -- unfortunately the kernels are created every call regardless, so this doesn't fix the problem directly and probably isn't even necessary, but I would say keep it because it is probably best that we don't initialize modules inside of a forward pass anyways.  I did suggest caching the kernels, so it might help in the future.

Once the associated torchvision patch and the a1111 optimizations go through, you can expect t2i-zero to run with almost no significant overhead compared to having it disabled.