### PR TITLE
Saliency-adaptive noise fusion for PAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Prompt: "A cute puppy on the moon", Min Rate: 0.5, Max Rate: 10.0
 https://arxiv.org/abs/2403.17377  
 An alternative/complementary method to CFG (Classifier-Free Guidance) that increases sampling quality.
 
+# Update: 20-05-2024
+Implemented a new feature called "Saliency-Adaptive Noise Fusion" derived from ["High-fidelity Person-centric Subject-to-Image Synthesis"](https://arxiv.org/abs/2311.10329).  
+
+This feature combines the guidance from PAG and CFG in an adaptive way that improves image quality especially at higher guidance scales.  
+
+Check out the paper authors' project repository here: https://github.com/CodeGoat24/Face-diffuser  
+
 #### Controls
 * **Use Saliency-Adaptive Noise Fusion**: Use improved method of combining CFG + PAG.
 * **PAG Scale**: Controls the intensity of effect of PAG on the generated image.  
@@ -286,6 +293,15 @@ SD XL
        eprint={2404.05384},
        archivePrefix={arXiv},
        primaryClass={cs.CV}
+      }
+    
+      @misc{wang2024highfidelity,
+        title={High-fidelity Person-centric Subject-to-Image Synthesis}, 
+        author={Yibin Wang and Weizhong Zhang and Jianwei Zheng and Cheng Jin},
+        year={2024},
+        eprint={2311.10329},
+        archivePrefix={arXiv},
+        primaryClass={cs.CV}
       }
 
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ https://arxiv.org/abs/2403.17377
 An alternative/complementary method to CFG (Classifier-Free Guidance) that increases sampling quality.
 
 #### Controls
+* **Use Saliency-Adaptive Noise Fusion**: Use improved method of combining CFG + PAG.
 * **PAG Scale**: Controls the intensity of effect of PAG on the generated image.  
 * **PAG Start Step**: Step to start using PAG.
 * **PAG End Step**: Step to stop using PAG. 


### PR DESCRIPTION
Adds a new method of combining the guidance from PAG and CFG.

Derives from "High-fidelity Person-centric Subject-to-Image Synthesis": https://arxiv.org/abs/2311.10329

In the paper they are combining the guidance from two different models, so I thought we could apply that to PAG since it's doing pretty much the same thing.


A couple of examples:

High CFG scales:
![xyz_grid-0012-1](https://github.com/v0xie/sd-webui-incantations/assets/28695009/e088563d-d65f-40ad-931f-4c84b46196f9)
![xyz_grid-0014-1](https://github.com/v0xie/sd-webui-incantations/assets/28695009/f89cf7f1-3b4f-4c48-8a22-a1f9c30598b7)

Greater than 512px for SD1.5:
![xyz_grid-0002-1](https://github.com/v0xie/sd-webui-incantations/assets/28695009/6614b7d9-bbe8-4768-95ce-cc1ada0b9e78)

Normal CFG scale, high PAG scale:
![xyz_grid-0000-1](https://github.com/v0xie/sd-webui-incantations/assets/28695009/6a169afa-f6ae-4f30-8ab6-f1af36016b51)
