### PR TITLE
Fix a shape mismatch with ControlNet for PAG

### DIFF
--- a/scripts/pag.py
+++ b/scripts/pag.py
@@ -359,7 +359,7 @@ class PAGExtensionScript(UIWrapper):
                         batch_size, seq_len, inner_dim = output.shape
                         identity = torch.eye(seq_len, dtype=last_to_v.dtype, device=shared.device).expand(batch_size, -1, -1)
                         if last_to_v is not None:    
-                                new_output = torch.einsum('bij,bjk->bik', identity, last_to_v)
+                                new_output = torch.einsum('bij,bjk->bik', identity, last_to_v[:, :seq_len, :])
                                 return new_output
                         else:
                                 # this is bad


### PR DESCRIPTION
This fixes a shape mismatch with controlnet that at least exists with the reference_only processor.   Possibly others too, but I haven't tested and this shouldn't wrongly affect anything except similar shape mismatches.

Basically using controlnet reference_only concats the last_to_v we get along the sequence length dimension.  This therefore takes only the first seq_len slices along that axis, resolving the issue.

There are still issues with controlnet, it does not work with batch sizes above 1 and I am still investigating (maybe this is a mercy, it's already slow enough combining this with controlnet at batch 1...).  But it can at least be used.