### PR TITLE
Better Save Attention Maps

### DIFF
--- a/scripts/incant_utils/plot_tools.py
+++ b/scripts/incant_utils/plot_tools.py
@@ -26,9 +26,7 @@ def plot_attention_map(attention_map: torch.Tensor, title, x_label="X", y_label=
                 ax.imshow(attention_map, cmap='viridis', interpolation='nearest')
         elif plot_type == 'num':
                 ax.imshow(attention_map, cmap='tab20c', interpolation='nearest')
-                #for x in range(attention_map.shape[0]):
-                #        for y in range(attention_map.shape[1]):
-                #                fig.text(x, y, f"{attention_map[x, y]:.2f}", ha="center", va="center")
+
                 elements = list(set(attention_map.flatten()))
                 labels = [f"{x}" for x in elements]
                 fig.legend(elements, labels, loc='lower left')
@@ -43,11 +41,3 @@ def plot_attention_map(attention_map: torch.Tensor, title, x_label="X", y_label=
                 plt.savefig(save_path)
         
         plt.close(fig)
-
-        # Show the plot
-        # plt.show()
-
-        # Convert the plot to PIL image
-        #image = Image.fromarray(np.uint8(fig.canvas.tostring_rgb()))
-
-        #return image

--- a/scripts/incant_utils/plot_tools.py
+++ b/scripts/incant_utils/plot_tools.py
@@ -9,8 +9,7 @@ def plot_attention_map(attention_map: torch.Tensor, title, x_label="X", y_label=
                         x_label: str (optional) - The x-axis label
                         y_label: str (optional) - The y-axis label
                         save_path: str (optional) - The path to save the plot
-                        plot_type: str (optional) - The type of plot to create. Default is 'default'. 
-                            Other option is 'num' which will plot the attention map with arbitrary colors.
+                        plot_type: str (optional) - The type of plot to create. Options: 'default', 'num', or any matplotlib colormap name. https://matplotlib.org/stable/gallery/color/colormap_reference.html
                 Returns:
                         None
         """
@@ -21,12 +20,17 @@ def plot_attention_map(attention_map: torch.Tensor, title, x_label="X", y_label=
         # Create figure and axis
         fig, ax = plt.subplots()
 
+        cmap_name = 'viridis'
+        match plot_type:
+                case 'default':
+                        cmap_name = 'viridis'
+                case 'num':
+                        cmap_name = 'tab20c'
+                case _:
+                        cmap_name = plot_type 
         # Plot the attention map
-        if plot_type=='default':
-                ax.imshow(attention_map, cmap='viridis', interpolation='nearest')
-        elif plot_type == 'num':
-                ax.imshow(attention_map, cmap='tab20c', interpolation='nearest')
-
+        ax.imshow(attention_map, cmap=cmap_name, interpolation='nearest')
+        if plot_type == 'num':
                 elements = list(set(attention_map.flatten()))
                 labels = [f"{x}" for x in elements]
                 fig.legend(elements, labels, loc='lower left')

--- a/scripts/incant_utils/prompt_utils.py
+++ b/scripts/incant_utils/prompt_utils.py
@@ -46,7 +46,7 @@ def tokenize_prompt(text):
     if isinstance(text, str):
         prompts = [text]
 
-    clip = getattr(sd_hijack, 'clip', None)
+    clip = getattr(sd_hijack.model_hijack, 'clip', None)
     if clip is None:
         return None, None
     batch_chunks, token_count = clip.process_texts(prompts)
@@ -61,7 +61,7 @@ def decode_tokenized_prompt(tokens):
         a list of tuples containing the token index, token, and decoded token
     
     """
-    clip = getattr(sd_hijack, 'clip', None)
+    clip = getattr(sd_hijack.model_hijack, 'clip', None)
     if clip is None:
         return None
     decoded_prompt = [

--- a/scripts/incant_utils/prompt_utils.py
+++ b/scripts/incant_utils/prompt_utils.py
@@ -65,6 +65,6 @@ def decode_tokenized_prompt(tokens):
     if clip is None:
         return None
     decoded_prompt = [
-        (token_idx, token, clip.tokenizer.decoder[token]) for token_idx, token in enumerate(tokens)
+        [token_idx, token, clip.tokenizer.decoder[token]] for token_idx, token in enumerate(tokens)
     ]
     return decoded_prompt

--- a/scripts/incant_utils/prompt_utils.py
+++ b/scripts/incant_utils/prompt_utils.py
@@ -12,8 +12,6 @@ def get_token_count(text, steps, is_positive: bool = True, return_tokens = False
         token_count: int - The total number of tokens in the prompt text
         max_length: int - The maximum length of the prompt text
     """
-
-
     try:
         text, _ = extra_networks.parse_prompt(text)
 
@@ -33,6 +31,7 @@ def get_token_count(text, steps, is_positive: bool = True, return_tokens = False
     prompts = [prompt_text for step, prompt_text in flat_prompts]
 
     token_count, max_length = max([sd_hijack.model_hijack.get_prompt_lengths(prompt) for prompt in prompts], key=lambda args: args[0])
+    return token_count, max_length
 
 
 def tokenize_prompt(text):

--- a/scripts/incant_utils/prompt_utils.py
+++ b/scripts/incant_utils/prompt_utils.py
@@ -6,8 +6,14 @@ from modules import sd_hijack
 
 # taken from modules/ui.py 
 # https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/ui.py
-def get_token_count(text, steps, is_positive: bool = True):
-    """ Get token count and max length for a given prompt text. """
+def get_token_count(text, steps, is_positive: bool = True, return_tokens = False):
+    """ Get token count and max length for a given prompt text. If return_tokens is True, return the tokens as well. 
+    Returns:
+        token_count: int - The total number of tokens in the prompt text
+        max_length: int - The maximum length of the prompt text
+    """
+
+
     try:
         text, _ = extra_networks.parse_prompt(text)
 
@@ -25,5 +31,41 @@ def get_token_count(text, steps, is_positive: bool = True):
 
     flat_prompts = reduce(lambda list1, list2: list1+list2, prompt_schedules)
     prompts = [prompt_text for step, prompt_text in flat_prompts]
+
     token_count, max_length = max([sd_hijack.model_hijack.get_prompt_lengths(prompt) for prompt in prompts], key=lambda args: args[0])
-    return token_count, max_length
+
+
+def tokenize_prompt(text):
+    """ Tokenize the given prompt text using the current clip model. 
+    Arguments:
+        text: str - The prompt text to tokenize
+
+    Returns:
+        tokens: list[int] - If return_tokens is True, return the tokenized prompt as well
+    
+    """
+    if isinstance(text, str):
+        prompts = [text]
+
+    clip = getattr(sd_hijack, 'clip', None)
+    if clip is None:
+        return None, None
+    batch_chunks, token_count = clip.process_texts(prompts)
+    return batch_chunks, token_count
+
+
+def decode_tokenized_prompt(tokens):
+    """ Decode the given tokenized prompt using the current clip model. 
+    Arguments:
+        tokens: list[int] - The tokenized prompt to decode
+    Returns:
+        a list of tuples containing the token index, token, and decoded token
+    
+    """
+    clip = getattr(sd_hijack, 'clip', None)
+    if clip is None:
+        return None
+    decoded_prompt = [
+        (token_idx, token, clip.tokenizer.decoder[token]) for token_idx, token in enumerate(tokens)
+    ]
+    return decoded_prompt

--- a/scripts/save_attn_maps.py
+++ b/scripts/save_attn_maps.py
@@ -66,6 +66,10 @@ class SaveAttentionMapsScript(UIWrapper):
         
         token_count, _= prompt_utils.get_token_count(p.prompt, p.steps, True)
 
+        if token_count <= 0:
+            logger.warning("No tokens found in prompt. Skipping saving attention maps.")
+            return
+
         setattr(p, 'savemaps_token_count', token_count)
         setattr(p, 'savemaps_step', 0)
 

--- a/scripts/save_attn_maps.py
+++ b/scripts/save_attn_maps.py
@@ -104,11 +104,14 @@ class SaveAttentionMapsScript(UIWrapper):
         latent_shape = [p.height // p.rng.shape[1], p.width // p.rng.shape[2]] # (height, width)
         
         save_steps = []
-        min_step = max(save_every_n_step, 0) 
+        min_step = max(save_every_n_step-1, 0) 
         if save_every_n_step > 0:
             save_steps = list(range(min_step, p.steps, save_every_n_step))
         else:
             save_steps = [p.steps-1]
+        # always save last step
+        if p.steps-1 not in save_steps:
+            save_steps.append(p.steps-1)
 
         # Create fields in module
         value_map = copy.deepcopy(module_field_map)

--- a/scripts/save_attn_maps.py
+++ b/scripts/save_attn_maps.py
@@ -291,38 +291,8 @@ class SaveAttentionMapsScript(UIWrapper):
                 )
 
                 if shared.state.interrupted:
+                    self.unhook_modules(module_list, copy.deepcopy(module_field_map))
                     return 
-            
-            # #for attn_map_idx in range(attn_map_num):
-            # #    for batch_idx in range(batch_num):
-            # for ohm_dict in one_hot_dict_maps:
-            #     attn_map_idx = ohm_dict['attn_map_idx']
-            #     batch_idx = ohm_dict['batch_idx']
-            #     map_seq_num = ohm_dict['seq_num']
-            #     one_hot_map = ohm_dict['attnmap']
-
-            #     try:
-            #         savestep_num = module.savemaps_save_steps[attn_map_idx] + 1
-            #     except IndexError:
-            #         logger.error(f"IndexError: attn_map_idx: {attn_map_idx}, attn_map_num: {attn_map_num}, save_steps: {module.savemaps_save_steps}")
-            #         savestep_num = attn_map_idx
-
-            #     out_file_name = f'{map_seq_num:04}-{module.network_layer_name}_step{savestep_num:04}_onehotmap_{attn_map_idx:04}_batch{batch_idx:04}.png'
-            #     out_save_path = os.path.join(save_image_path, out_file_name)
-
-            #     plot_title = f"{module.network_layer_name}\n"\
-            #         f"Step {savestep_num}, "\
-
-            #     plot_tools.plot_attention_map(
-            #         attention_map = one_hot_map,
-            #         title = plot_title,
-            #         save_path = out_save_path,
-            #         plot_type = "plasma"
-            #     )
-            #     if shared.state.interrupted:
-            #         return
-
-
         self.unhook_modules(module_list, copy.deepcopy(module_field_map))
 
     def create_base_dict(self, plot_type:str, base_seq_num: int, network_layer_name: str, save_steps: list, attn_map_idx: int, batch_idx: int, attnmap: torch.Tensor, filename_info: str, plot_color: str):

--- a/scripts/save_attn_maps.py
+++ b/scripts/save_attn_maps.py
@@ -131,7 +131,7 @@ class SaveAttentionMapsScript(UIWrapper):
             """
             for module in module_list:
                 module.savemaps_step = p.savemaps_step
-            logger.debug('Setting step to %d for %d modules', p.savemaps_step, len(module_list))
+            # logger.debug('Setting step to %d for %d modules', p.savemaps_step, len(module_list))
             p.savemaps_step += 1
         
         script_callbacks.on_cfg_denoiser(on_cfg_denoiser)
@@ -312,7 +312,7 @@ class SaveAttentionMapsScript(UIWrapper):
 
         #for module, kv in zip(module_list, value_map.items()):
         for module in module_list:
-            logger.debug('Adding hook to %s', module.network_layer_name)
+            # logger.debug('Adding hook to %s', module.network_layer_name)
             for key_name, default_value in value_map.items():
                 module_hooks.modules_add_field(module, key_name, default_value)
 
@@ -344,6 +344,8 @@ class SaveAttentionMapsScript(UIWrapper):
             for key_name, _ in value_map.items():
                 module_hooks.modules_remove_field(module, key_name)
             module_hooks.modules_remove_field(module, 'savemaps_is_self')
+            module_hooks.modules_remove_field(module, 'savemaps_token_count')
+            module_hooks.modules_remove_field(module, 'savemaps_token_indices')
             module_hooks.remove_module_forward_hook(module, 'savemaps_hook')
             for module_name in SUBMODULES:
                 module_hooks.modules_remove_field(module, f'savemaps_{module_name}_map')

--- a/scripts/save_attn_maps.py
+++ b/scripts/save_attn_maps.py
@@ -216,7 +216,7 @@ class SaveAttentionMapsScript(UIWrapper):
                         token_idx, token_id, word = tokenized_prompts[batch_idx][token_idx]
 
                         fn_pad_zeroes = lambda num: f"{num:04}"
-                        savestep_num = module.savemaps_save_steps[attn_map_idx]
+                        savestep_num = module.savemaps_save_steps[attn_map_idx] + 1
                         attn_map = attn_maps[attn_map_idx, batch_idx, token_idx]
                         out_file_name = f'{module.network_layer_name}_token{token_idx:04}_step{savestep_num:04}_attnmap_{attn_map_idx:04}_batch{batch_idx:04}.png'
                         save_path = os.path.join(save_image_path, out_file_name)

--- a/scripts/save_attn_maps.py
+++ b/scripts/save_attn_maps.py
@@ -38,17 +38,18 @@ class SaveAttentionMapsScript(UIWrapper):
     
     def setup_ui(self, is_img2img) -> list:
         with gr.Accordion('Save Attention Maps', open = False):
-            active = gr.Checkbox(label = 'Active', default = False)
-            export_folder = gr.Textbox(label = 'Export Folder', value = 'attention_maps', info = 'Folder to save attention maps to as a subdirectory of the outputs.')
+            with gr.Row():
+                active = gr.Checkbox(label = 'Active', default = False)
+                map_types = gr.CheckboxGroup(
+                    label = 'Map Types',
+                    choices = ['One-Hot Map', 'Per-Token Maps'],
+                    value = ['One-Hot Map'],
+                    info = 'Select the type of attention maps to save.',
+                )
+            export_folder = gr.Textbox(visible=False, label = 'Export Folder', value = 'attention_maps', info = 'Folder to save attention maps to as a subdirectory of the outputs.')
             module_name_filter = gr.Textbox(label = 'Module Names', value = 'input_blocks_5_1_transformer_blocks_0_attn2', info = 'Module name to save attention maps for. If the substring is found in the module name, the attention maps will be saved for that module.')
             class_name_filter = gr.Textbox(label = 'Class Name Filter', value = 'CrossAttention', info = 'Filters eligible modules by the class name.')
             save_every_n_step = gr.Slider(label = 'Save Every N Step', value = 0, min = 0, max = 100, step = 1, info = 'Save attention maps every N steps. 0 to save last step.')
-            map_types = gr.CheckboxGroup(
-                label = 'Map Types',
-                choices = ['One-Hot Map', 'Per-Token Maps'],
-                value = ['One-Hot Map'],
-                info = 'Select the type of attention maps to save.',
-            )
             print_modules = gr.Button(value = 'Print Modules To Console')
             print_modules.click(self.print_modules, inputs=[module_name_filter, class_name_filter])
 


### PR DESCRIPTION
Refactors the Save Attention Maps script for plotting cross attention maps
Adds options for different attention map filtering (Per-Token Attention Maps, One-Hot Argmax maps)
Each plot shows the token index, the token id (tokenized word), and the word associated with the token id.
Adds a unique sequence number to the beginning of the saved files to prevent overwriting old files


![image](https://github.com/v0xie/sd-webui-incantations/assets/28695009/f830314f-7118-46b5-b8ff-be477ed7d172)
![image](https://github.com/v0xie/sd-webui-incantations/assets/28695009/528e00e6-2806-4236-a263-033a4ece727e)
