### PR TITLE
Autoguidance

### DIFF
--- a/scripts/cfg_combiner.py
+++ b/scripts/cfg_combiner.py
@@ -200,7 +200,8 @@ def combine_denoised_pass_conds_list(*args, **kwargs):
                 # 3. Saliency Map
                 use_saliency_map = False
                 if pag_params is not None:
-                        use_saliency_map = pag_params.pag_sanf
+                        use_saliency_map = True # temp for fair comparison
+                        #use_saliency_map = pag_params.pag_sanf
                 
 
                 ### Combine Denoised

--- a/scripts/pag.py
+++ b/scripts/pag.py
@@ -191,7 +191,7 @@ class PAGExtensionScript(UIWrapper):
                         pag_sanf = gr.Checkbox(value=False, default=False, label="Use Saliency-Adaptive Noise Fusion", elem_id='pag_sanf')
                         autoguidance = gr.Checkbox(value=False, default=False, label="Use Autoguidance", elem_id='pag_ag', info="Put networks in between !!<lora:network:1>!! in prompt")
                         with gr.Row():
-                                pag_scale = gr.Slider(value = 0, minimum = 0, maximum = 20.0, step = 0.5, label="PAG Scale", elem_id = 'pag_scale', info="")
+                                pag_scale = gr.Slider(value = 0, minimum = 0, maximum = 40.0, step = 0.5, label="PAG Scale", elem_id = 'pag_scale', info="")
                                 lerp_factor = gr.Slider(value = 1.0, minimum = 0, maximum = 1, step = 0.1, label="Lerp Factor", elem_id = 'pag_lerp_factor', info="")
                         with gr.Row():
                                 start_step = gr.Slider(value = 0, minimum = 0, maximum = 150, step = 1, label="Start Step", elem_id = 'pag_start_step', info="")


### PR DESCRIPTION
Really WIP implementation of autoguidance (https://arxiv.org/abs/2406.02507)

Instead of a secondary model we use a Lora model.
Extremely slow because we have to unload/reload the networks each step.
Ideally we merge the weights to a model and load a second copy into memory?

Wrap the Lora text in the prompt with `!!` symbols: `!!<lora:name:1.0>!!`
The noise prediction from the lora model will be used for the "bad" guidance. Idea being you can use a poorly trained / over-trained Lora as bad guidance.